### PR TITLE
Ignore case sensitivity in run_autograder

### DIFF
--- a/templates/exam-manual/run_autograder
+++ b/templates/exam-manual/run_autograder
@@ -6,7 +6,7 @@ RESULTS_TEMPLATE="results_template_success" # Default to success template
 # Check if file names match config
 missing_files=()
 while read -r required_file; do
-    if [ ! -f "submission/$required_file" ]
+    if [ -z "$(find submission -type f -iname "$required_file")" ]
     then
         missing_files+=("$required_file")
     fi
@@ -22,7 +22,7 @@ then
         RESULTS_TEMPLATE="download_starter_code_template"
     else
         # Not the first submission
-        file_count=$(find submission -type f -name "*.java" | wc -l)
+        file_count=$(find submission -type f -iname "*.java" | wc -l)
         if [ $file_count -eq 0 ]
         then
             RESULTS_TEMPLATE="results_template_no_java_files"

--- a/templates/homework-manual/run_autograder
+++ b/templates/homework-manual/run_autograder
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Check if any Java files were submitted
-file_count=$(find submission -type f -name "*.java" | wc -l)
+file_count=$(find submission -type f -iname "*.java" | wc -l)
 if [ $file_count -eq 0 ]
 then
     cp /autograder/source/results_template_no_java_files /autograder/results/results.json
@@ -11,7 +11,7 @@ fi
 # Check if file names match config
 missing_files=()
 while read -r required_file; do
-    if [ ! -f "submission/$required_file" ]
+    if [ -z "$(find submission -type f -iname "$required_file")" ]
     then
         missing_files+=("$required_file")
     fi


### PR DESCRIPTION
This fixes #23 by ignoring case when checking file names. The fix uses the `find` command, which should allow for wildcard patterns once these are supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved file existence checks to be case-insensitive, ensuring more accurate identification and counting of Java files in submissions.
	- Enhanced search method for checking missing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->