### PR TITLE
Enforce list editing in builder tool

### DIFF
--- a/builder/src/main/java/rhit/presentation/ConfigurationOptions.java
+++ b/builder/src/main/java/rhit/presentation/ConfigurationOptions.java
@@ -80,59 +80,69 @@ class ConfigurationOptions extends SwingGui {
       formPanel.add(new JLabel(keyLabel + ": "), gbc);
       gbc.gridx = 1;
       if (value instanceof JSONArray) {
-        if (key.toString().equals("classes")) {
-          InterfaceUtils.createClassObjectsFromPackages((JSONArray) value,
-              BuilderData.getTemplateFiles());
-        }
-        JButton button = new JButton(PropertiesLoader.get("editButton"));
-        didVisitArrayEditor.put(key.toString(), false);
-        button.addActionListener(e -> {
-          didVisitArrayEditor.put(key.toString(), true);
-          displayArrayEditor((JSONArray) value);
-        });
-        formPanel.add(button, gbc);
+        addArrayEditOption(key.toString(), (JSONArray) value, formPanel, gbc);
       } else {
-        JTextField textField = new JTextField(value.toString());
-        formValues.put(key.toString(), value.toString());
-        textField.getDocument().addDocumentListener(new DocumentListener() {
-          @Override
-          public void insertUpdate(DocumentEvent e) {
-            handleChange();
-          }
-
-          @Override
-          public void removeUpdate(DocumentEvent e) {
-            handleChange();
-          }
-
-          @Override
-          public void changedUpdate(DocumentEvent e) {
-            handleChange();
-          }
-
-          private void handleChange() {
-            Object newValue = textField.getText();
-            formValues.put(key.toString(), (String) newValue);
-            if (((String) newValue).isEmpty()) {
-              return;
-            }
-            if (value instanceof Long) {
-              newValue = Long.parseLong((String) newValue);
-            } else if (value instanceof Boolean) {
-              newValue = Boolean.parseBoolean((String) newValue);
-            }
-            configOptions.put(key, newValue);
-          }
-        });
-        formPanel.add(textField, gbc);
+        addTextFieldOption(key, value, configOptions, formPanel, gbc);
       }
       gbc.gridy++;
     });
   }
 
+  private void addArrayEditOption(String label, JSONArray array, JPanel formPanel,
+      GridBagConstraints gbc) {
+    if (label.equals("classes")) {
+      InterfaceUtils.createClassObjectsFromPackages(array, BuilderData.getTemplateFiles());
+    }
+    JButton button = new JButton(PropertiesLoader.get("editButton"));
+    didVisitArrayEditor.put(label, false);
+    button.addActionListener(e -> {
+      didVisitArrayEditor.put(label, true);
+      displayArrayEditor(array);
+    });
+    formPanel.add(button, gbc);
+  }
+
   private void displayArrayEditor(JSONArray array) {
     ArrayEditorDialog dialog = new ArrayEditorDialog(frame, array);
     dialog.setVisible(true);
+  }
+
+  private void addTextFieldOption(Object label, Object value, JSONObject configOptions,
+      JPanel formPanel, GridBagConstraints gbc) {
+    JTextField textField = new JTextField(value.toString());
+    formValues.put(label.toString(), value.toString());
+    textField.getDocument().addDocumentListener(new DocumentListener() {
+      @Override
+      public void insertUpdate(DocumentEvent e) {
+        handleChange();
+      }
+
+      @Override
+      public void removeUpdate(DocumentEvent e) {
+        handleChange();
+      }
+
+      @Override
+      public void changedUpdate(DocumentEvent e) {
+        handleChange();
+      }
+
+      @SuppressWarnings("unchecked")
+      private void handleChange() {
+        Object newValue = textField.getText();
+        formValues.put(label.toString(), (String) newValue);
+        if (((String) newValue).isEmpty()) {
+          return;
+        }
+        if (value instanceof Long) {
+          newValue = Long.parseLong((String) newValue);
+        } else if (value instanceof Boolean) {
+          newValue = Boolean.parseBoolean((String) newValue);
+        }
+        configOptions.put(label, newValue);
+      }
+    });
+    formPanel.add(textField, gbc);
   }
 
   protected void handleContinue() {

--- a/builder/src/main/java/rhit/presentation/ConfigurationOptions.java
+++ b/builder/src/main/java/rhit/presentation/ConfigurationOptions.java
@@ -25,12 +25,14 @@ class ConfigurationOptions extends SwingGui {
 
   private final JFrame frame;
   private final Map<String, String> formValues;
+  private final Map<String, Boolean> didVisitArrayEditor;
   private JPanel panel;
 
   ConfigurationOptions() {
     this.frame = InterfaceUtils.getFrame();
     super.verifyFrame(frame);
     this.formValues = new HashMap<>();
+    this.didVisitArrayEditor = new HashMap<>();
     BuilderData.parseConfigFile();
   }
 
@@ -65,7 +67,7 @@ class ConfigurationOptions extends SwingGui {
 
   @SuppressWarnings("unchecked")
   private void iterativeFormPanel(JSONObject configOptions, JPanel formPanel,
-                                  GridBagConstraints gbc) {
+      GridBagConstraints gbc) {
     configOptions.forEach((key, value) -> {
       if (value instanceof JSONObject) {
         iterativeFormPanel((JSONObject) value, formPanel, gbc);
@@ -83,7 +85,11 @@ class ConfigurationOptions extends SwingGui {
               BuilderData.getTemplateFiles());
         }
         JButton button = new JButton(PropertiesLoader.get("editButton"));
-        button.addActionListener(e -> displayArrayEditor((JSONArray) value));
+        didVisitArrayEditor.put(key.toString(), false);
+        button.addActionListener(e -> {
+          didVisitArrayEditor.put(key.toString(), true);
+          displayArrayEditor((JSONArray) value);
+        });
         formPanel.add(button, gbc);
       } else {
         JTextField textField = new JTextField(value.toString());
@@ -132,6 +138,10 @@ class ConfigurationOptions extends SwingGui {
   protected void handleContinue() {
     if (formValues.values().stream().anyMatch(String::isEmpty)) {
       JOptionPane.showMessageDialog(frame, PropertiesLoader.get("emptyFieldError"));
+      return;
+    }
+    if (didVisitArrayEditor.values().stream().anyMatch(visited -> !visited)) {
+      JOptionPane.showMessageDialog(frame, PropertiesLoader.get("arrayEditorError"));
       return;
     }
     InterfaceUtils.hideFrame(panel);

--- a/builder/src/main/resources/Strings.properties
+++ b/builder/src/main/resources/Strings.properties
@@ -28,6 +28,7 @@ addItem=Enter new item
 editItem=Edit item
 detailsEditorTitle=Enter Details
 emptyFieldError=Fields cannot be empty!
+arrayEditorError=Please click the edit button for all arrays to make sure data is correct.
 typeError=The value for %s is the wrong type!
 didNotSave=Item did not save.
 doneButton=Done


### PR DESCRIPTION
This PR requires users of the builder tool to check config lists content before processing the autograder files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The form now enforces review of all array sections before proceeding, ensuring data accuracy.
  - A new, clear error message guides users to verify each array edit when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->